### PR TITLE
Remove absurd requirement that the script be run as root

### DIFF
--- a/54-missilelauncher.rules
+++ b/54-missilelauncher.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="2123", MODE="0664", GROUP="plugdev"

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ There are a few projects for using older launchers in Linux, but I couldn't find
 This script requires PyUSB 1.0+, apt in Debian/Ubuntu installs 0.4.
 
 Also, on Debian\Ubuntu systems you need the __python-imaging-tk__
-    
-It also requires that you run it as root unless you want to spend an afternoon playing with udev rules :/
+
+
 
 ## Getting Started:
 
     git clone git@github.com:nmilford/stormLauncher.git
     cd stormLauncher
-    chmod +x stormLauncher.py
-    sudo ./stormLauncher.py
+    sudo cp 54-missilelauncher.rules /etc/udev/rules.d
+    sudo service udev restart
+    ./stormLauncher.py
 
 ## Usage:
 

--- a/stormLauncher.py
+++ b/stormLauncher.py
@@ -90,7 +90,7 @@ class launchControl(Frame):
 
    def turretUp(self, event):
       self.message1.set("Turret Up.")
-      self.dev.ctrl_transfer(0x21,0x09,0,0,[0x02,0x02,0x00,0x00,0x00,0x00,0x00,0x00]) 
+      self.dev.ctrl_transfer(0x21,0x09,0,0,[0x02,0x02,0x00,0x00,0x00,0x00,0x00,0x00])
 
    def turretDown(self, event):
       self.message1.set("Turret Down.")
@@ -121,6 +121,4 @@ class launchControl(Frame):
 
 
 if __name__ == '__main__':
-   if not os.geteuid() == 0:
-       sys.exit("Script must be run as root.")
    launchControl().mainloop()


### PR DESCRIPTION
I've included udev rules that will allow anyone in the `plugdev` group to use the launcher (or anything else from that vendor), although the udev rule is easy enough to modify if you want to change that.
